### PR TITLE
up

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,20 +1,20 @@
 {
-    "words_limit": {
-        "description": "每个关键词允许的词条数",
-        "type": "int",
-        "hint": "超过此限制将无法继续添加",
-        "default": 10
-    },
-    "delete_msg_time": {
-            "description": "定义几秒后撤回消息",
-            "type": "int",
-            "hint": "0表示不撤回消息, 不允许超过120秒, 否则无法撤回",
-            "default": 0
-    },
     "need_prefix": {
         "description": "是否需要前缀唤醒bot",
         "type": "bool",
         "hint": "",
         "default": true
+    },
+    "recall_time": {
+        "description": "定义几秒后撤回消息",
+        "type": "int",
+        "hint": "0表示不撤回消息, 不允许超过120秒, 否则无法撤回",
+        "default": 0
+    },
+    "words_limit": {
+        "description": "每个关键词允许的词条数",
+        "type": "int",
+        "hint": "超过此限制将无法继续添加",
+        "default": 10
     }
 }

--- a/data.py
+++ b/data.py
@@ -1,10 +1,10 @@
 import json
-from typing import List
+from pathlib import Path
 from random import choice
 
 
 class KeywordReplyDB:
-    def __init__(self, path: str):
+    def __init__(self, path: Path):
         """初始化关键词数据库并从指定路径加载数据"""
         self.path = path
         self.data = self._load()
@@ -12,7 +12,7 @@ class KeywordReplyDB:
     def _load(self) -> dict:
         """加载 JSON 文件内容"""
         try:
-            with open(self.path, "r", encoding="utf-8") as f:
+            with open(self.path, encoding="utf-8") as f:
                 return json.load(f)
         except FileNotFoundError:
             return {}
@@ -60,14 +60,14 @@ class KeywordReplyDB:
                 return True
         return False
 
-    def list_entries(self, keyword: str) -> List[str]:
+    def list_entries(self, keyword: str) -> list[str]:
         """列出关键词下的所有词条"""
         resolved = self._resolve_keyword(keyword)
         if resolved is not None:
             return self.data[resolved]["entries"]
         return []
 
-    def set_alias(self, keyword: str, aliases: List[str]):
+    def set_alias(self, keyword: str, aliases: list[str]):
         """设置关键词的别名列表"""
         self.add_keyword(keyword)
         self.data[keyword]["alias"] = aliases
@@ -114,7 +114,7 @@ class KeywordReplyDB:
             del self.data[keyword]
             self.save()
 
-    def get_all_keywords(self) -> List[str]:
+    def get_all_keywords(self) -> list[str]:
         """获取所有关键词（含别名）"""
         all_keys = []
         for key, value in self.data.items():

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
-name: astrbot_plugin_wbank # 这是你的插件的唯一识别名。
+name: astrbot_plugin_wbank
 display_name: 自定义词库
-desc: 动态词库，自定义回复词 # 插件简短描述
-version: v1.0.4 # 插件版本号。格式：v1.1.1 或者 v1.1
-author: Zhalslar # 作者
-repo: https://github.com/Zhalslar/astrbot_plugin_wbank # 插件的仓库地址
+desc: 动态词库，自定义回复词
+version: v1.1.0
+author: Zhalslar
+repo: https://github.com/Zhalslar/astrbot_plugin_wbank


### PR DESCRIPTION
## Summary by Sourcery

重构词库插件以使用集中化的配置与路径工具，同时更新类型注解与元数据。

新特性：
- 支持可配置的消息撤回时间，用于自动删除已发送的消息。

缺陷修复：
- 确保非 OneBot 平台在发送回复时不会尝试执行撤回操作，从而避免平台相关错误。

增强与优化：
- 直接使用插件数据目录的 Path 对象来管理默认词库文件。
- 使用存储的配置对象替代对配置属性的直接访问，以便更方便地获取各类限制与开关。
- 在关键词回复数据库中使用内建泛型类型以现代化类型注解。
- 通过将注册信息移动到 `metadata.yaml` 并移除内联装饰器注册来简化插件元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the word bank plugin to use centralized configuration and path utilities while updating type hints and metadata.

New Features:
- Support configurable message recall time for automatically deleting sent messages.

Bug Fixes:
- Ensure non-OneBot platforms send replies without attempting recall operations, preventing platform-specific errors.

Enhancements:
- Use the plugin data directory Path object directly for managing the default word bank file.
- Replace direct config attribute usage with a stored configuration object for easier access to limits and flags.
- Modernize type hints in the keyword reply database to use built-in generic types.
- Simplify plugin metadata by moving registration details to metadata.yaml and removing inline decorator registration.

</details>